### PR TITLE
When retrieving server id call (existing) physical resource id 

### DIFF
--- a/custom_resources/transfer.py
+++ b/custom_resources/transfer.py
@@ -58,6 +58,7 @@ class User(LambdaBackedCustomResource):
                     "transfer:ImportSshPublicKey",
                     "transfer:List*",
                     "transfer:UpdateUser",
+                    "iam:PassRole"
                 ],
                 "Resource": "*",
             }],

--- a/lambda_code/transfer/Server/index.py
+++ b/lambda_code/transfer/Server/index.py
@@ -60,7 +60,7 @@ class Server(CloudFormationCustomResource):
         return required
 
     def get_attributes(self):
-        return {'ServerId': self.server_id}
+        return {'ServerId': self.physical_resource_id}
 
     def create(self):
         transfer_client = self.get_boto3_client('transfer')


### PR DESCRIPTION
There was an error in the server custom resource:

_Custom resource Server failed due to exception "'Server' object has no attribute 'server_id'"._

Because I now use physical_resource_id to keep the server id, hence this attribute never gets set. So the solution is either to refer to physical resource id, or alternatively, to set server id as well. Here I picked approach one.