### PR TITLE
APC-649 Create a custom resource for Amazon Cloudwatch Logs ResourcePolicy

### DIFF
--- a/custom_resources/logs.py
+++ b/custom_resources/logs.py
@@ -1,0 +1,25 @@
+"""
+Custom resource to support Amazon Cloudwatch Logs ResourcePolicy as Cloudformation doesn't support this yet.
+You can vote to support it at https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/249
+"""
+from .LambdaBackedCustomResource import LambdaBackedCustomResource
+
+
+class ResourcePolicy(LambdaBackedCustomResource):
+    props = {
+        'PolicyDocument': (dict, True),
+    }
+
+    @classmethod
+    def _lambda_policy(cls):
+        return {
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": [
+                    "logs:PutResourcePolicy",
+                    "logs:DeleteResourcePolicy",
+                ],
+                "Resource": "*",
+            }],
+        }

--- a/lambda_code/logs/ResourcePolicy/index.py
+++ b/lambda_code/logs/ResourcePolicy/index.py
@@ -1,0 +1,36 @@
+"""
+Custom resource to support Amazon Cloudwatch Logs ResourcePolicy.
+https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_ResourcePolicy.html
+https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutResourcePolicy.html
+https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DeleteResourcePolicy.html
+"""
+
+from cfn_custom_resource import CloudFormationCustomResource
+from _metadata import CUSTOM_RESOURCE_NAME
+
+
+class ResourcePolicy(CloudFormationCustomResource):
+    RESOURCE_TYPE_SPEC = CUSTOM_RESOURCE_NAME
+
+    def validate(self):
+        self.policy_doc = self.resource_properties['PolicyDocument']
+
+    def create(self):
+        cl = self.get_boto3_client('logs')
+        cl.put_resource_policy(policyName=self.physical_resource_id, policyDocument=self.policy_doc)
+        return {}
+
+    def update(self):
+        return self.create()
+
+    def delete(self):
+        cl = self.get_boto3_client('logs')
+        try:
+            cl.delete_resource_policy(policyName=self.physical_resource_id)
+        except (cl.exceptions.ResourceNotFoundException,
+                cl.exceptions.InvalidParameterException):
+            # Assume already deleted
+            pass
+
+
+handler = ResourcePolicy.get_handler()

--- a/lambda_code/logs/ResourcePolicy/requirements.txt
+++ b/lambda_code/logs/ResourcePolicy/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/iRobotCorporation/cfn-custom-resource#egg=cfn-custom-resource


### PR DESCRIPTION
This will enable logging of error/slow query logs in Elasticsearch.

I'm not sure what I'm doing here, so better to open this PR and get early feedback.