### PR TITLE
Add new custom resource: elasticsearch.IngestPipeline

### DIFF
--- a/custom_resources/elasticsearch.py
+++ b/custom_resources/elasticsearch.py
@@ -1,0 +1,22 @@
+"""Custom resources related to Elasticsearch."""
+from six import string_types
+from .LambdaBackedCustomResource import LambdaBackedCustomResource
+
+
+class IngestPipeline(LambdaBackedCustomResource):
+    props = {
+        'EsHost': (string_types, True),
+        'PipelineName': (string_types, True),
+        'IngestDocument': (dict, True),
+    }
+
+    @classmethod
+    def _lambda_policy(cls):
+        return {
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "es:ESHttp*",
+                "Resource": "*",
+            }],
+        }

--- a/lambda_code/elasticsearch/IngestPipeline/index.py
+++ b/lambda_code/elasticsearch/IngestPipeline/index.py
@@ -1,0 +1,38 @@
+"""
+Custom resource to create an ingest pipeline in your AWS Elasticsearch Cluster.
+"""
+
+import json
+import requests
+from cfn_custom_resource import CloudFormationCustomResource
+from _metadata import CUSTOM_RESOURCE_NAME
+
+
+class IngestPipeline(CloudFormationCustomResource):
+    RESOURCE_TYPE_SPEC = CUSTOM_RESOURCE_NAME
+
+    def validate(self):
+        self.es_host = self.resource_properties['EsHost']
+        self.pipeline_name = self.resource_properties['PipelineName']
+        self.ingest_doc = self.resource_properties['IngestDocument']
+
+    def create(self):
+        url = 'https://' + self.es_host + '/_ingest/pipeline/' + self.pipeline_name
+        requests.put(url, json.dumps(self.ingest_doc))
+        return {}
+
+    def update(self):
+        return self.create()
+
+    def delete(self):
+        url = 'https://' + self.es_host + '/_ingest/pipeline/' + self.pipeline_name
+        try:
+            requests.delete(url)
+        except (requests.exceptions.Timeout,
+                requests.exceptions.TooManyRedirects,
+                requests.exceptions.RequestException):
+            # Assume already deleted
+            pass
+
+
+handler = IngestPipeline.get_handler()

--- a/lambda_code/elasticsearch/IngestPipeline/requirements.txt
+++ b/lambda_code/elasticsearch/IngestPipeline/requirements.txt
@@ -1,0 +1,2 @@
+git+https://github.com/iRobotCorporation/cfn-custom-resource#egg=cfn-custom-resource
+requests


### PR DESCRIPTION
I have added a new custom resource: elasticsearch.IngestPipeline.

Ingest pipelines let you perform common transformations on your data before indexing. For example, you can use pipelines to remove fields, extract values from text, and enrich your data.