### PR TITLE
Add support for parsing (multiple) json formatted ssm parameters

### DIFF
--- a/custom_resources/ssm.py
+++ b/custom_resources/ssm.py
@@ -63,10 +63,7 @@ class ParseDict(LambdaBackedCustomResource):
             "Statement": [{
                 "Effect": "Allow",
                 "Action": [
-                    "ssm:DescribeParameters",
-                    "ssm:GetParameter",
                     "ssm:GetParameters",
-                    "ssm:GetParametersByPath",
                 ],
                 "Resource": "*",
             }],

--- a/custom_resources/ssm.py
+++ b/custom_resources/ssm.py
@@ -52,7 +52,7 @@ class Parameter(LambdaBackedCustomResource):
 
 class ParseDict(LambdaBackedCustomResource):
     props = {
-        'Name': (string_types, True),  # The parameter path including namespace
+        'Names': ([string_types], True),  # The parameter paths including namespace
         'Serial': (string_types, False),  # Use this to force an update
     }
 

--- a/custom_resources/ssm.py
+++ b/custom_resources/ssm.py
@@ -48,3 +48,34 @@ class Parameter(LambdaBackedCustomResource):
         """
         # Keep legacy non-structured name for backward compatibility
         return ['SsmParameter']
+
+
+class ParseDict(LambdaBackedCustomResource):
+    props = {
+        'Name': (string_types, True),  # The parameter path including namespace
+        'Serial': (string_types, False),  # Use this to force an update
+    }
+
+    @classmethod
+    def _lambda_policy(cls):
+        return {
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": [
+                    "ssm:DescribeParameters",
+                    "ssm:GetParameter",
+                    "ssm:GetParameters",
+                    "ssm:GetParametersByPath",
+                ],
+                "Resource": "*",
+            }],
+        }
+
+    @classmethod
+    def name(cls):
+        """
+        :rtype: List[str]
+        """
+        # Avoid Injecting `0` in name by setting it statically
+        return ['SsmParseDict']

--- a/lambda_code/ssm/ParseDict/index.py
+++ b/lambda_code/ssm/ParseDict/index.py
@@ -37,7 +37,9 @@ class ParseDict(CloudFormationCustomResource):
 
     def create(self):
         ssm = self.get_boto3_client('ssm')
+        print(f"Retrieving parameter with path '{self.name}'")
         param = ssm.get_parameter(Name=self.name)
+        print(f"Got value: '{param['Parameter']['Value']}'")
         return json.loads(param['Parameter']['Value'])
 
     def update(self):

--- a/lambda_code/ssm/ParseDict/index.py
+++ b/lambda_code/ssm/ParseDict/index.py
@@ -1,0 +1,50 @@
+"""ParseDict custom resource.
+
+ParseDict custom resource lambda to read json formatted ssm ps parameters
+and return them in easy to work with dict structures.
+"""
+import os
+import json
+
+from cfn_custom_resource import CloudFormationCustomResource
+
+try:
+    from _metadata import CUSTOM_RESOURCE_NAME
+except ImportError:
+    CUSTOM_RESOURCE_NAME = 'dummy'
+
+REGION = os.environ['AWS_REGION']
+
+
+class ParseDict(CloudFormationCustomResource):
+    """
+    ssm.ParseDict.
+
+    Properties:
+        Name: str: Name of the Parameter (including namespace)
+    """
+
+    RESOURCE_TYPE_SPEC = CUSTOM_RESOURCE_NAME
+    # TODO: figure out if we need this or not
+    # DISABLE_PHYSICAL_RESOURCE_ID_GENERATION = True
+
+    def validate(self):
+        self.name = self.resource_properties.get('Name')
+        if not self.name:
+            return False
+        return True
+
+    def create(self):
+        ssm = self.get_boto3_client('ssm')
+        param = ssm.get_parameter(Name=self.name)
+        return json.loads(param['Parameter']['Value'])
+
+    def update(self):
+        return self.create()
+
+    def delete(self):
+        # Nothing to delete
+        pass
+
+
+handler = ParseDict.get_handler()

--- a/lambda_code/ssm/ParseDict/index.py
+++ b/lambda_code/ssm/ParseDict/index.py
@@ -3,6 +3,7 @@
 ParseDict custom resource lambda to read json formatted ssm ps parameters
 and return them in easy to work with dict structures.
 """
+from collections import ChainMap
 import os
 import json
 
@@ -21,26 +22,25 @@ class ParseDict(CloudFormationCustomResource):
     ssm.ParseDict.
 
     Properties:
-        Name: str: Name of the Parameter (including namespace)
+        Names: List[str]: List of parameter paths (including namespace) to read
         Serial: str: Use this to force an update
     """
 
     RESOURCE_TYPE_SPEC = CUSTOM_RESOURCE_NAME
-    # TODO: figure out if we need this or not
-    # DISABLE_PHYSICAL_RESOURCE_ID_GENERATION = True
 
     def validate(self):
-        self.name = self.resource_properties.get('Name')
-        if not self.name:
+        self.names = self.resource_properties.get('Names')
+        if not self.names:
             return False
         return True
 
     def create(self):
         ssm = self.get_boto3_client('ssm')
-        print(f"Retrieving parameter with path '{self.name}'")
-        param = ssm.get_parameter(Name=self.name)
-        print(f"Got value: '{param['Parameter']['Value']}'")
-        return json.loads(param['Parameter']['Value'])
+        print(f"Retrieving parameters with paths '{self.names}'")
+        params = ssm.get_parameters(Names=self.names)
+        value = dict(ChainMap(*[json.loads(param['Value']) for param in params['Parameters']]))
+        print(f"Got merged value: '{value}'")
+        return value
 
     def update(self):
         return self.create()

--- a/lambda_code/ssm/ParseDict/index.py
+++ b/lambda_code/ssm/ParseDict/index.py
@@ -22,6 +22,7 @@ class ParseDict(CloudFormationCustomResource):
 
     Properties:
         Name: str: Name of the Parameter (including namespace)
+        Serial: str: Use this to force an update
     """
 
     RESOURCE_TYPE_SPEC = CUSTOM_RESOURCE_NAME

--- a/lambda_code/ssm/ParseDict/requirements.txt
+++ b/lambda_code/ssm/ParseDict/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/iRobotCorporation/cfn-custom-resource#egg=cfn-custom-resource


### PR DESCRIPTION
This PR adds a custom resource that can read a json formatted SSM PS parameter and return it as a Python dict. This dict can then be queried using the `GetAtt` function in cloudformation. This approach allows for introducing dynamic mappings on cloudformation level.

If multiple parameters are requested, the resulting dictionaries are merged in one.