### PR TITLE
Feature/mysql

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "lambda_code/mysql/MySQLUser"]
 	path = lambda_code/mysql/MySQLUser
 	url = https://github.com/vrtdev/cfn-mysql-user-provider.git
-	branch = feature/mysql-connection-timeout
+	branch = release/patch3

--- a/custom_resources/mysql.py
+++ b/custom_resources/mysql.py
@@ -6,6 +6,9 @@ from .LambdaBackedCustomResource import LambdaBackedCustomResource
 class MySQLUser(LambdaBackedCustomResource):
     props = {
         'User': (string_types, True),
+        'Grant': ([string_types], True),
+        'GrantOn': (string_types, True),
+        'WithGrantOption': (bool, False),
         'Password': (string_types, False),
         'PasswordParameterName': (string_types, False),
         'PasswordSecretName': (string_types, False),


### PR DESCRIPTION
Hello,

this PR adds grant support inside Custom::MySQLUser and 3 additional properties:
```
- `Grant` - the privileges to grant
- `GrantOn` - the privilege level to grant, use . for global grants. Update requires replacement.
- `WithGrantOption` - if the user is allowed to grant others, defaults to false
```

As seen from the demo-stack.yaml:
```
      Grant:
      - 'SELECT'
      GrantOn: 'root.*'
      WithGrantOption: false
```