### PR TITLE
Add Lambda LayerVersion custom resource with DeletionPolicy support

### DIFF
--- a/custom_resources/awslambda.py
+++ b/custom_resources/awslambda.py
@@ -47,6 +47,12 @@ class LayerVersion(LambdaBackedCustomResource):
     }
 
     @classmethod
+    def _update_lambda_settings(cls, settings):
+        # It can take a while before the layer is published
+        settings['Timeout'] = 300
+        return settings
+
+    @classmethod
     def _lambda_policy(cls):
         return {
             "Version": "2012-10-17",

--- a/custom_resources/awslambda.py
+++ b/custom_resources/awslambda.py
@@ -33,3 +33,39 @@ class Version(LambdaBackedCustomResource):
         """
         # Keep legacy non-structured name for backward compatibility
         return ['LambdaVersion']
+
+
+class LayerVersion(LambdaBackedCustomResource):
+    props = {
+        'LayerName': (string_types, True),
+        'Content': (dict, True),
+        'Description': (string_types, False),
+        'LicenseInfo': (string_types, False),
+        'CompatibleArchitecture': ([string_types], False),
+        'CompatibleRuntimes': ([string_types], False),
+        'DeletionPolicy': (string_types, False),
+    }
+
+    @classmethod
+    def _lambda_policy(cls):
+        return {
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": [
+                    "lambda:ListLayers",
+                    "lambda:ListLayerVersions",
+                    "lambda:PublishLayerVersion",
+                    "lambda:DeleteLayerVersion",
+                ],
+                "Resource": "*",
+            }],
+        }
+
+    @classmethod
+    def name(cls):
+        """
+        :rtype: List[str]
+        """
+        # Keep legacy non-structured name for backward compatibility
+        return ['LambdaLayerVersion']

--- a/custom_resources/awslambda.py
+++ b/custom_resources/awslambda.py
@@ -57,6 +57,7 @@ class LayerVersion(LambdaBackedCustomResource):
                     "lambda:ListLayerVersions",
                     "lambda:PublishLayerVersion",
                     "lambda:DeleteLayerVersion",
+                    "s3:GetObject",
                 ],
                 "Resource": "*",
             }],

--- a/lambda_code/awslambda/LayerVersion/index.py
+++ b/lambda_code/awslambda/LayerVersion/index.py
@@ -38,6 +38,8 @@ class LayerVersion(CloudFormationCustomResource):
     def create(self):
         result = self.get_boto3_client('lambda').publish_layer_version(**self.kwargs)
         self.physical_resource_id = result['LayerVersionArn']
+        self.resource_outputs['LayerName'] = self.resource_properties['LayerName']
+        self.resource_outputs['LayerVersionArn'] = result['LayerVersionArn']
         return {}
 
     def update(self):

--- a/lambda_code/awslambda/LayerVersion/index.py
+++ b/lambda_code/awslambda/LayerVersion/index.py
@@ -1,0 +1,55 @@
+import os
+
+from cfn_custom_resource import CloudFormationCustomResource
+from _metadata import CUSTOM_RESOURCE_NAME
+
+
+REGION = os.environ['AWS_REGION']
+
+
+class LayerVersion(CloudFormationCustomResource):
+    RESOURCE_TYPE_SPEC = CUSTOM_RESOURCE_NAME
+    DISABLE_PHYSICAL_RESOURCE_ID_GENERATION = True  # Use version ARN instead
+
+    def validate(self):
+        try:
+            self.kwargs = {
+                'LayerName': self.resource_properties['LayerName'],
+                'Content': {
+                   'S3Bucket': self.resource_properties['Content']['S3Bucket'],
+                   'S3Key': self.resource_properties['Content']['S3Key'],
+                },
+            }
+            if 'S3ObjectVersion' in self.resource_properties['Content']:
+               self.kwargs['Content']['S3ObjectVersion'] = self.resource_properties['Content']['S3ObjectVersion']
+            if 'CompatibleArchitectures' in self.resource_properties:
+                self.kwargs['CompatibleArchitectures'] = self.resource_properties['CompatibleArchitectures']
+            if 'CompatibleRuntimes' in self.resource_properties:
+                self.kwargs['CompatibleRuntimes'] = self.resource_properties['CompatibleRuntimes']
+            if 'Description' in self.resource_properties:
+                self.kwargs['Description'] = self.resource_properties['Description']
+            if 'LicenseInfo' in self.resource_properties:
+                self.kwargs['LicenseInfo'] = self.resource_properties['LicenseInfo']
+            return True
+
+        except (AttributeError, KeyError):
+            return False
+
+    def create(self):
+        result = self.get_boto3_client('lambda').publish_layer_version(**self.kwargs)
+        self.physical_resource_id = result['LayerVersionArn']
+        return {}
+
+    def update(self):
+        return self.create()
+
+    def delete(self):
+        if self.resource_properties.get('DeletionPolicy', "") == "Retain":
+            return
+        self.get_boto3_client('lambda').delete_layer_version(
+            LayerName=self.resource_properties['LayerName'],
+            Version=self.physical_resource_id.rsplit(':', 1)[-1]
+        )
+
+
+handler = LayerVersion.get_handler()

--- a/lambda_code/awslambda/LayerVersion/requirements.txt
+++ b/lambda_code/awslambda/LayerVersion/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/iRobotCorporation/cfn-custom-resource#egg=cfn-custom-resource


### PR DESCRIPTION
Adds custom resource to manager lambda LayerVersion resources with additional support for `DeletionPolicy`. By default, when updating a lambda layer, the previous version was automatically removed, making it unusable as a shared resource (or to perform asynchronous updates to the layer and its users). This custom resource keeps the older versions around if desired.