### PR TITLE
Set S3.Object Timeout to 10 seconds

### DIFF
--- a/custom_resources/s3.py
+++ b/custom_resources/s3.py
@@ -14,6 +14,11 @@ class Object(LambdaBackedCustomResource):
     }
 
     @classmethod
+    def _update_lambda_settings(cls, settings):
+        settings['Timeout'] = 10
+        return settings
+
+    @classmethod
     def _lambda_policy(cls):
         return {
             "Version": "2012-10-17",


### PR DESCRIPTION
Default 3 seconds timeout is a bit aggressive, since it sometimes takes more than 3 seconds to put an object and send a response back.