### PR TITLE
Increase global lambda timeout to 6 seconds

### DIFF
--- a/custom_resources/LambdaBackedCustomResource.py
+++ b/custom_resources/LambdaBackedCustomResource.py
@@ -115,6 +115,7 @@ class LambdaBackedCustomResource(CustomResource):
             'Description': Sub('{name} - ${{AWS::StackName}}'.format(name=cls.resource_type)),
             'Handler': 'index.handler',
             'Runtime': 'python3.9',
+            'Timeout': '6',  # Increase default timeout from 3 seconds, as some lambda's hover at that threshold
         }
         settings = cls._update_lambda_settings(default_settings)
         return settings


### PR DESCRIPTION
We've encountered timeouts at 3 seconds (previous default), several times now for different custom resources. This PR will increase the global timeout default to a more generous 6 seconds.