### PR TITLE
Add support to expose ec2 instance ipv6 address

### DIFF
--- a/custom_resources/ec2.py
+++ b/custom_resources/ec2.py
@@ -2,6 +2,23 @@ from six import string_types
 
 from .LambdaBackedCustomResource import LambdaBackedCustomResource
 
+class InstanceIpv6Address(LambdaBackedCustomResource):
+    props = {
+        'InstanceId': (string_types, True),  # e.g. i-1234567890abcdef0
+    }
+
+    @classmethod
+    def _lambda_policy(cls):
+        return {
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": [
+                    "ec2:DescribeNetworkInterfaces",
+                ],
+                "Resource": "*",
+            }],
+        }
 
 class FindAmi(LambdaBackedCustomResource):
     props = {

--- a/lambda_code/ec2/InstanceIpv6Address/index.py
+++ b/lambda_code/ec2/InstanceIpv6Address/index.py
@@ -1,0 +1,61 @@
+"""
+Custom Resource for extracting the ipv6 address of an EC2 instance.
+
+This feature is currently not supported natively by cloudformation.
+An open feature request can be found here:
+https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/916
+This custom resource will check the network interface of the given instance and output
+the associated ipv6 address.
+
+Parameters:
+ * InstanceId: a single InstanceId
+
+Return:
+  Attributes:
+   - Ipv6Address: The ipv6 address of the given instance
+"""
+import os
+
+from cfn_custom_resource import CloudFormationCustomResource
+try:
+    from _metadata import CUSTOM_RESOURCE_NAME
+except ImportError:
+    CUSTOM_RESOURCE_NAME = 'dummy'
+
+REGION = os.environ['AWS_REGION']
+
+
+class InstanceIpv6Address(CloudFormationCustomResource):
+    """
+    ec2.InstanceIpv6Address
+
+    Properties:
+        InstanceId: str: The instance id to retrieve the ipv6 address from
+    """
+    RESOURCE_TYPE_SPEC = CUSTOM_RESOURCE_NAME
+
+    def validate(self):
+        self.instance_id = self.resource_properties['InstanceId']
+        return self.instance_id.startswith("i-")
+
+    def create(self):
+        ec2_client = self.get_boto3_client('ec2')
+        print(f"Retrieving network interface info for '{self.instance_id}'")
+        resp = ec2_client.describe_network_interfaces(
+            Filters=[{'Name':'attachment.instance-id', 'Values':[self.instance_id] }]
+        )
+        address = resp.get('NetworkInterfaces')[0]['Ipv6Address']
+        print(f"Found address '{address}' associated with instance '{self.instance_id}'")
+        return {
+            'Ipv6Address': address
+        }
+
+    def update(self):
+        return self.create()
+
+    def delete(self):
+        # Nothing to delete
+        pass
+
+
+handler = InstanceIpv6Address.get_handler()

--- a/lambda_code/ec2/InstanceIpv6Address/requirements.txt
+++ b/lambda_code/ec2/InstanceIpv6Address/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/iRobotCorporation/cfn-custom-resource#egg=cfn-custom-resource


### PR DESCRIPTION
Retrieving the IPv6 address via cfn is not natively supported for ec2 instances, see https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/916. This custom resource can be used to extract it anyways.