### PR TITLE
Use `_` instead of `-` in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,3 @@
 # Inside of setup.cfg
 [metadata]
-description-file = README.md
+description_file = README.md


### PR DESCRIPTION
Otherwise installation fails (with setuptools >= 78.0.0)

See https://github.com/pypa/setuptools/blob/main/NEWS.rst#v7800

Warning for this deprecation initially introduced in 3 Mar 2021